### PR TITLE
downgrade CommunityToolkit.Mvvm and Microsoft nugets to use .net6 dlls

### DIFF
--- a/src/vsix/StartPagePlus.csproj
+++ b/src/vsix/StartPagePlus.csproj
@@ -222,13 +222,19 @@
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="CommunityToolkit.Mvvm">
-      <Version>8.1.0</Version>
+      <Version>8.0.0</Version>
     </PackageReference>
     <PackageReference Include="EnvDTE80">
       <Version>17.5.33428.366</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
+      <Version>6.0.0</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
-      <Version>7.0.0</Version>
+      <Version>6.0.1</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions">
+      <Version>6.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Shell.15.0" ExcludeAssets="runtime">
       <Version>17.0.32112.339</Version>


### PR DESCRIPTION
downgrade CommunityToolkit.Mvvm and Microsoft nugets to use .net6 dlls and maybe this fixes #10 